### PR TITLE
Articles : 2 guides OSINT FR (recherche de personne + vérification d'entreprise)

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@
 - [Dutchosintguy](https://www.dutchosintguy.com/post/beyond-dashboards-osint-s-next-two-decades) - Vision prospective OSINT moderne
 - [Géolocaliser une image](https://manufacture-osint.fr/tutoriel-comment-geolocaliser-une-image-avec-losint/) - Tutorial complet géolocalisation images
 - [Acceder au information publique FR](https://gijn.org/fr/histoires/comment-acceder-a-des-informations-publiques-en-france/) - Guide accès données publiques France
+- [Trouver des informations sur une personne (FR)](https://verisources.fr/guides/trouver-informations-publiques-quelquun) - Guide légal et gratuit de recherche d'informations publiques sur une personne
+- [Vérifier la fiabilité d'une entreprise (FR)](https://verisources.fr/guides/verifier-fiabilite-entreprise-gratuitement) - Méthode gratuite via Infogreffe, Sirene et registres officiels
 - [Nothing2hide/osint](https://wiki.nothing2hide.org/doku.php?id=start&do=index) - Wiki OSINT complet et encyclopédique
 - [Maltego tuto](https://wondersmithrae.medium.com/a-beginners-guide-to-osint-investigation-with-maltego-6b195f7245cc) - Guide débutant Maltego
 - [Osint tool](https://osint.tools/) - Moteur de recherche outils OSINT


### PR DESCRIPTION
Bonjour, merci pour ce hub, ressource vraiment utile pour la communauté OSINT francophone.

J'ajoute deux guides francophones gratuits et légaux dans la section **Articles**, dans la même veine que l'entrée GIJN "Accéder aux informations publiques FR" déjà présente :

- **Trouver des informations sur une personne** : méthode légale et gratuite de recherche d'informations publiques sur une personne.
- **Vérifier la fiabilité d'une entreprise** : méthode gratuite via Infogreffe, Sirene et les registres officiels (complète bien la section Bases de Données Publiques France).

Les deux sont publiés sur verisources.fr, un annuaire indépendant d'agences d'enquête/OSINT et des guides de vérification de sources. Aucune obligation de merger, à vous de juger si ça a sa place. Bonne continuation.