### PR TITLE
Correction lien mort (Manufacture OSINT) + ajout guide outils OSINT debutants FR

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,11 +65,12 @@
 - [Acceder au information publique FR](https://gijn.org/fr/histoires/comment-acceder-a-des-informations-publiques-en-france/) - Guide accès données publiques France
 - [Trouver des informations sur une personne (FR)](https://verisources.fr/guides/trouver-informations-publiques-quelquun) - Guide légal recherche infos publiques sur une personne
 - [Vérifier la fiabilité d'une entreprise (FR)](https://verisources.fr/guides/verifier-fiabilite-entreprise-gratuitement) - Méthode gratuite via Infogreffe, Sirene et registres officiels
+- [Outils OSINT gratuits pour débutants (FR)](https://verisources.fr/guides/outils-osint-gratuits-debutants) - Sélection d'outils OSINT gratuits et méthode pas à pas pour débuter
 - [Nothing2hide/osint](https://wiki.nothing2hide.org/doku.php?id=start&do=index) - Wiki OSINT complet et encyclopédique
 - [Maltego tuto](https://wondersmithrae.medium.com/a-beginners-guide-to-osint-investigation-with-maltego-6b195f7245cc) - Guide débutant Maltego
 - [Osint tool](https://osint.tools/) - Moteur de recherche outils OSINT
 - [Osint Linkedin](https://medium.com/ax1al/the-unconventional-guide-to-conducting-osint-on-linkedin-c9631b27935d) - Techniques recherche LinkedIn
-- [Manufacture OSINT - Blog](https://manufacture-osint.fr/blog/) - Guides pratiques, tutoriels géolocalisation
+- [Manufacture OSINT - Blog](https://manufacture-osint.fr/posts/) - Guides pratiques, tutoriels géolocalisation
 - [Bellingcat Blog](https://www.bellingcat.com/) - Cas d'études GEOINT analyse satellite
 - [WebBreacher - Tips & Tricks](https://webbreacher.com/) - Astuces OSINT pratiques, analyses cas
 - [OSINT Curious - Articles](https://www.osintcurio.us/) - Ressources archivées, guides techniques


### PR DESCRIPTION
Bonjour Adrien,

Suite a votre invitation (detecter des liens obsoletes et proposer d'autres merge), deux petites contributions a la section Articles :

1. **Correction d'un lien mort.** Le lien "Manufacture OSINT - Blog" pointait vers `https://manufacture-osint.fr/blog/` qui renvoie une 404. Le blog est maintenant sous `/posts/` (verifie 200). J'ai corrige l'URL.

2. **Ajout d'un guide (auto-promotion assumee).** J'ajoute notre guide "Outils OSINT gratuits pour debutants", dans la continuite de nos deux guides deja references. Il complete les entrees debutants existantes (Career guide, Six Pillars) avec une selection d'outils gratuits et une methode pas a pas, en francais.

J'ai garde le format existant de la liste. N'hesitez pas a ajuster le libelle ou a ne retenir que la correction du lien mort si l'ajout ne vous convient pas.

Merci pour le hub,
Thomas
