### PR TITLE
Add DNSai to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@
 - [Chromewebstore](https://chromewebstore.google.com/detail/clean-tabs/aghbkaaajenibjoinlhcpcobnboebhme) - Extension Chrome OSINT
 - [liveuamap](https://liveuamap.com/) - Cartographie événements temps réel
 - [Manhole](https://manhole.co.il/coversMap.asp?sr=all%3D1) - Cartographie infrastructure souterraine
+- [DNSai](https://dnsai.com/dns-tools/) - Free DNS, WHOIS, SPF/DKIM/DMARC and blacklist lookups with plain-English results; free API and MCP server, no signup
 
 #### 🔓 Outils Open-Source (Performants & Peu Connus)
 - [Holehe](https://github.com/megadose/holehe) - Vérifie si un email est associé à différentes plateformes web


### PR DESCRIPTION
Adds DNSai to the Tools section. DNSai offers free DNS, WHOIS, SPF/DKIM/DMARC and blacklist lookups with plain-English results, plus a free API and MCP server for AI assistants (no signup) — useful for domain-infrastructure OSINT. Entry is in English, matching the list's mixed FR/EN style.

Disclosure: I'm affiliated with DNSai. Happy to translate to French or adjust placement to fit the list.